### PR TITLE
Update to 5.7

### DIFF
--- a/wiconfig
+++ b/wiconfig
@@ -266,7 +266,7 @@ function scan {
 		# MAC
 		echo -n "|$4" >> $output
 		# Signal quality
-		printf "|%02d" ${5%dB} >> $output
+		printf "|%02d" ${5%dBm} >> $output
 		# Speed
 		echo -n "|$6" >> $output
 		# Options


### PR DESCRIPTION
In 5.7, ifconfig display signal quality with dBm instead of dB.
This fix the printf call by correctly remove the unit.