### PR TITLE
No need to sort with ignore-leading-blanks

### DIFF
--- a/wiconfig
+++ b/wiconfig
@@ -278,7 +278,7 @@ function scan {
 	# Wireless network(s) found
 	if [ -s "$output" ]; then
 		# Sort nwids by greatest signal quality
-		sort -brk 4 -o "$input" -t "|" "$output"
+		sort -rk 4 -o "$input" -t "|" "$output"
 	else
 		if ! $quiet; then
 			rescan


### PR DESCRIPTION
Since request #1, the signal has padding.
And there is a [bug in 5.8 about reverse and ignore-leading-blanks](https://marc.info/?l=openbsd-bugs&m=144565377222741&w=2) which makes wiconfig selects the lowest signal network instead of the higher.